### PR TITLE
Deploy app using Capifony

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,4 @@
+load 'deploy' if respond_to?(:namespace) # cap2 differentiator
+
+require 'capifony_symfony2'
+load 'app/config/deploy'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'capifony', '~> 2.8.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    capifony (2.8.3)
+      capistrano (>= 2.13.5, <= 2.16.0)
+      capistrano-maintenance (= 0.0.3)
+      colored (>= 1.2.0)
+      inifile (>= 2.0.2, < 3.0.0)
+      ruby-progressbar (= 1.4.1)
+    capistrano (2.15.5)
+      highline
+      net-scp (>= 1.0.0)
+      net-sftp (>= 2.0.0)
+      net-ssh (>= 2.0.14)
+      net-ssh-gateway (>= 1.1.0)
+    capistrano-maintenance (0.0.3)
+      capistrano (>= 2.0.0)
+    colored (1.2)
+    highline (1.7.1)
+    inifile (2.0.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    ruby-progressbar (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  capifony (~> 2.8.3)

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -28,7 +28,6 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle();
             $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
             $bundles[] = new Hautelook\AliceBundle\HautelookAliceBundle();
             $bundles[] = new Liip\FunctionalTestBundle\LiipFunctionalTestBundle();

--- a/app/config/deploy.rb
+++ b/app/config/deploy.rb
@@ -1,0 +1,57 @@
+set :application, "slims"
+set :domain,      ""
+set :deploy_to,   "/var/www/#{application}"
+set :app_path,    "app"
+
+set :user,             "ubuntu"
+set :use_sudo,         false
+set :interactive_mode, false
+
+# Repository
+set :repository,  "https://github.com/littlerobot/slims.git"
+set :scm,         :git
+set :branch,      "master"
+set :deploy_via,  :remote_cache
+
+set :model_manager, "doctrine"
+
+# Files and folders that are shared between deployments
+set :shared_files,        ["app/config/parameters.yml"]
+set :shared_children,     [app_path + "/logs", web_path + "/uploads"]
+
+# Parameters
+set :parameters_dir, "app/config/parameters"
+set :parameters_file, false
+
+# Vendors
+set :copy_vendors, true
+
+# Composer
+set :use_composer, true
+set :composer_options,  "--prefer-dist --optimize-autoloader --no-progress"
+
+# File permissions
+set :writable_dirs,       ["app/cache", "app/logs"]
+set :webserver_user,      "www-data"
+set :permission_method,   :acl
+set :use_set_permissions, true
+
+role  :web,           domain
+role  :app,           domain, :primary => true
+
+set  :keep_releases,  5
+
+after "deploy:share_childs", "upload_parameters"
+after "deploy", "deploy:cleanup"
+before "symfony:cache:warmup", "symfony:doctrine:migrations:migrate"
+
+task :upload_parameters do
+  origin_file = "app/config/parameters.yml"
+  destination_file = latest_release + "/app/config/parameters.yml"
+
+  try_sudo "mkdir -p #{File.dirname(destination_file)}"
+  top.upload(origin_file, destination_file)
+end
+
+# Be more verbose by uncommenting the following line
+ logger.level = Logger::MAX_LEVEL

--- a/puphpet/config.yaml
+++ b/puphpet/config.yaml
@@ -53,7 +53,7 @@ vagrantfile-local:
         username: vagrant
         guest_port: null
         keep_alive: true
-        forward_agent: false
+        forward_agent: true
         forward_x11: false
         shell: 'bash -l'
     vagrant:


### PR DESCRIPTION
- Gemfile and configuration for Capifony.
- Update config.yaml to forward SSH keys so app can be deployed from within VM.
- Move DoctrineMigrationsBundle into normal AppKernel bundle registration so it is available during the cap:deploy:migrations stage.